### PR TITLE
show milliseconds timestamp in utc timezone

### DIFF
--- a/src/modules/SearchTerms/components/View/presenter.tsx
+++ b/src/modules/SearchTerms/components/View/presenter.tsx
@@ -223,11 +223,11 @@ function Term(props: ITermProps) {
               }
               <ListItem>
                 <span {...classes('attribute-name')}>Valid start</span>
-                <span>{moment(validStart, 'x').format(commonDateFormat)}</span>
+                <span>{moment.utc(validStart).format(commonDateFormat)}</span>
               </ListItem>
               <ListItem>
                 <span {...classes('attribute-name')}>Valid end</span>
-                <span>{moment(validEnd, 'x').format(commonDateFormat)}</span>
+                <span>{moment.utc(validEnd).format(commonDateFormat)}</span>
               </ListItem>
             </ul>
           </Panel>


### PR DESCRIPTION
Connect start and end dates should be displayed in UTC timezone so that it were displayed agnostic to user timezone. Closes OHDSI/Athena#56