### PR TITLE
An explicit button click for the refresh instead of polling on the Download History screen

### DIFF
--- a/src/modules/Vocabulary/components/DownloadHistory/container.ts
+++ b/src/modules/Vocabulary/components/DownloadHistory/container.ts
@@ -63,7 +63,7 @@ implements IDownloadHistory {
 
   componentWillMount() {
     this.props.load();
-    this.startPolling();
+    // this.startPolling();
   }
 
   componentWillUnmount() {

--- a/src/modules/Vocabulary/components/DownloadHistory/presenter.tsx
+++ b/src/modules/Vocabulary/components/DownloadHistory/presenter.tsx
@@ -169,6 +169,7 @@ function VocabsList(props: IDownloadHistoryProps & IDownloadHistoryStatefulProps
     expandedBundleId,
     restoreBundle,
     share,
+    load,
     showNotifications,
     showShareModal,
     download,
@@ -182,6 +183,7 @@ function VocabsList(props: IDownloadHistoryProps & IDownloadHistoryStatefulProps
         caption='Download history'
         backUrl={paths.vocabsList()}
       >
+        <Button {...classes('download-button')} onClick={load}>Refresh</Button>
         <Button onClick={showNotifications} mods={['submit', 'rounded']}>Notifications</Button>
       </Toolbar>
       <Accordion activeItems={[expandedBundleId]}>


### PR DESCRIPTION
https://github.com/OHDSI/Athena/issues/231